### PR TITLE
Fix removing keys by specifying the key type explicitly

### DIFF
--- a/internal/provider/key_resource.go
+++ b/internal/provider/key_resource.go
@@ -294,6 +294,7 @@ func (r *keyResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		UID:       state.User.ValueString(),
 		SubUser:   state.Subuser.ValueString(),
 		AccessKey: state.AccessKey.ValueString(),
+		KeyType:   "s3",
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(


### PR DESCRIPTION
It seems that the radosgw admin API silently requires the `key-type` parameter, even though it is documented as "Required: No" in the docs: https://docs.ceph.com/en/latest/radosgw/adminops/#remove-key

When `key-type` is not set, the following rather unhelpful error message is given:

    Could not remove key "OG1ET0FUQ3KBN8GFG08X": InvalidAccessKeyId tx000007e1f216de31cbd68-0065522ca3-101c-default 101c-default-default

Verified the fix with our `docker compose` setup and commenting out the `demo_readonly_key` resource in `examples/provider/provider.tf` after running `terraform apply` once to create it.